### PR TITLE
feat: Testnet support

### DIFF
--- a/hyperfuel-client/Cargo.toml
+++ b/hyperfuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-client"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 description = "client library for Envio's HyperSync support of the Fuel Network"
 license = "MIT"
@@ -36,8 +36,8 @@ alloy-json-abi = "0.5.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 hyperfuel-net-types = { package = "hyperfuel-net-types", path = "../hyperfuel-net-types", version = "0.0.3" }
-hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "0.0.4" }
-hyperfuel-schema = { package = "hyperfuel-schema", path = "../hyperfuel-schema", version = "0.0.2" }
+hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "0.0.5" }
+hyperfuel-schema = { package = "hyperfuel-schema", path = "../hyperfuel-schema", version = "0.0.3" }
 
 [dependencies.reqwest]
 version = "0.11"

--- a/hyperfuel-client/Cargo.toml
+++ b/hyperfuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-client"
-version = "0.0.8"
+version = "1.0.0"
 edition = "2021"
 description = "client library for Envio's HyperSync support of the Fuel Network"
 license = "MIT"
@@ -35,9 +35,9 @@ alloy-dyn-abi = "0.5.0"
 alloy-json-abi = "0.5.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
-hyperfuel-net-types = { package = "hyperfuel-net-types", path = "../hyperfuel-net-types", version = "0.0.3" }
-hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "0.0.5" }
-hyperfuel-schema = { package = "hyperfuel-schema", path = "../hyperfuel-schema", version = "0.0.3" }
+hyperfuel-net-types = { package = "hyperfuel-net-types", path = "../hyperfuel-net-types", version = "1.0.0" }
+hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "1.0.0" }
+hyperfuel-schema = { package = "hyperfuel-schema", path = "../hyperfuel-schema", version = "1.0.0" }
 
 [dependencies.reqwest]
 version = "0.11"

--- a/hyperfuel-client/src/from_arrow.rs
+++ b/hyperfuel-client/src/from_arrow.rs
@@ -89,6 +89,18 @@ impl FromArrow for BlockHeader {
             }
         }
 
+        if let Ok(col) = batch.column::<UInt64Array>("consensus_parameters_version") {
+            for (target, &val) in out.iter_mut().zip(col.values_iter()) {
+                target.consensus_parameters_version = val.into();
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("state_transition_bytecode_version") {
+            for (target, &val) in out.iter_mut().zip(col.values_iter()) {
+                target.state_transition_bytecode_version = val.into();
+            }
+        }
+
         if let Ok(col) = batch.column::<UInt64Array>("transactions_count") {
             for (target, val) in out.iter_mut().zip(col.values_iter()) {
                 target.transactions_count = val.to_be_bytes().into();
@@ -107,9 +119,15 @@ impl FromArrow for BlockHeader {
             }
         }
 
-        if let Ok(col) = batch.column::<BinaryArray<i32>>("message_receipt_root") {
+        if let Ok(col) = batch.column::<BinaryArray<i32>>("message_outbox_root") {
             for (target, val) in out.iter_mut().zip(col.values_iter()) {
-                target.message_receipt_root = val.try_into().unwrap();
+                target.message_outbox_root = val.try_into().unwrap();
+            }
+        }
+
+        if let Ok(col) = batch.column::<BinaryArray<i32>>("event_inbox_root") {
+            for (target, val) in out.iter_mut().zip(col.values_iter()) {
+                target.event_inbox_root = val.try_into().unwrap();
             }
         }
 
@@ -213,15 +231,33 @@ impl FromArrow for Transaction {
             }
         }
 
-        if let Ok(col) = batch.column::<UInt64Array>("gas_price") {
+        if let Ok(col) = batch.column::<UInt64Array>("policies_tip") {
             for (target, val) in out.iter_mut().zip(col.iter()) {
-                target.gas_price = val.copied().map(|n| n.into());
+                target.policies_tip = val.copied().map(|n| n.into());
             }
         }
 
-        if let Ok(col) = batch.column::<UInt64Array>("gas_limit") {
+        if let Ok(col) = batch.column::<UInt64Array>("policies_witness_limit") {
             for (target, val) in out.iter_mut().zip(col.iter()) {
-                target.gas_limit = val.copied().map(|n| n.into());
+                target.policies_witness_limit = val.copied().map(|n| n.into());
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("policies_maturity") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.policies_maturity = val.copied().map(|n| n.into());
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("policies_max_fee") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.policies_max_fee = val.copied().map(|n| n.into());
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("script_gas_limit") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.script_gas_limit = val.copied().map(|n| n.into());
             }
         }
 
@@ -240,6 +276,12 @@ impl FromArrow for Transaction {
         if let Ok(col) = batch.column::<BinaryArray<i32>>("mint_asset_id") {
             for (target, val) in out.iter_mut().zip(col.iter()) {
                 target.mint_asset_id = val.map(|v| v.try_into().unwrap());
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("mint_gas_price") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.mint_gas_price = val.copied().map(|n| n.into());
             }
         }
 
@@ -327,9 +369,50 @@ impl FromArrow for Transaction {
             }
         }
 
-        if let Ok(col) = batch.column::<UInt64Array>("bytecode_length") {
+        if let Ok(col) = batch.column::<BinaryArray<i32>>("bytecode_root") {
             for (target, val) in out.iter_mut().zip(col.iter()) {
-                target.bytecode_length = val.copied().map(|t| t.into());
+                target.bytecode_root = val.map(|v| v.try_into().unwrap());
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("subsection_index") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.subsection_index = val.copied().map(|t| t.into());
+            }
+        }
+
+        if let Ok(col) = batch.column::<UInt64Array>("subsections_number") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.subsections_number = val.copied().map(|t| t.into());
+            }
+        }
+
+        if let Ok(col) = batch.column::<BinaryArray<i32>>("proof_set") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.proof_set = val.map(|v| v.into());
+            }
+        }
+
+        if let Ok(col) =
+            batch.column::<UInt64Array>("consensus_parameters_upgrade_purpose_witness_index")
+        {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.consensus_parameters_upgrade_purpose_witness_index =
+                    val.copied().map(|t| t.into());
+            }
+        }
+
+        if let Ok(col) =
+            batch.column::<BinaryArray<i32>>("consensus_parameters_upgrade_purpose_checksum")
+        {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.consensus_parameters_upgrade_purpose_checksum = val.map(|v| v.into());
+            }
+        }
+
+        if let Ok(col) = batch.column::<BinaryArray<i32>>("state_transition_upgrade_purpose_root") {
+            for (target, val) in out.iter_mut().zip(col.iter()) {
+                target.state_transition_upgrade_purpose_root = val.map(|v| v.try_into().unwrap());
             }
         }
 

--- a/hyperfuel-client/src/lib.rs
+++ b/hyperfuel-client/src/lib.rs
@@ -7,9 +7,8 @@ use anyhow::{anyhow, Context, Result};
 use arrow2::{array::Array, chunk::Chunk};
 
 use filter::filter_out_unselected_data;
-use format::{Transaction, TransactionStatus};
 use from_arrow::{receipts_from_arrow_data, typed_data_from_arrow_data, FromArrow};
-use hyperfuel_format::Hash;
+use hyperfuel_format::{Hash, Transaction, TransactionStatus};
 use hyperfuel_net_types::{
     hyperfuel_net_types_capnp, ArchiveHeight, FieldSelection, Query, ReceiptSelection,
 };
@@ -23,7 +22,6 @@ mod transport_format;
 mod types;
 
 pub use config::Config;
-pub use hyperfuel_format as format;
 pub use transport_format::{ArrowIpc, TransportFormat};
 pub use types::{
     ArrowBatch, LogContext, LogResponse, QueryResponse, QueryResponseData, QueryResponseDataTyped,

--- a/hyperfuel-format/Cargo.toml
+++ b/hyperfuel-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-format"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "fuel network format library"
 license = "MIT"

--- a/hyperfuel-format/Cargo.toml
+++ b/hyperfuel-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-format"
-version = "0.0.5"
+version = "1.0.0"
 edition = "2021"
 description = "fuel network format library"
 license = "MIT"

--- a/hyperfuel-format/src/types/mod.rs
+++ b/hyperfuel-format/src/types/mod.rs
@@ -35,12 +35,17 @@ pub struct BlockHeader {
     pub da_height: UInt,
     /// The number of transactions in the block.
     pub transactions_count: Quantity,
+    /// version of consensus
+    pub consensus_parameters_version: UInt,
+    /// version of the state transition
+    pub state_transition_bytecode_version: UInt,
     /// The number of receipt messages in the block.
     pub message_receipt_count: Quantity,
     /// The merkle root of the transactions in the block.
     pub transactions_root: Hash,
-    /// The merkle root of the receipt messages in the block.
-    pub message_receipt_root: Hash,
+    /// The merkle root of the messages in the block.
+    pub message_outbox_root: Hash,
+    pub event_inbox_root: Hash,
     /// The block height.
     pub height: UInt,
     /// The merkle root of all previous consensus header hashes (not including this block).
@@ -84,17 +89,20 @@ pub struct Transaction {
     /// A pointer to the TX whose output is being spent for a contract used for the transaction input.
     pub input_contract_tx_pointer_tx_index: Option<UInt>,
     /// The contract id for a contract used for the transaction input.
-    pub input_contract: Option<ContractId>,
-    /// The gas price for the transaction.
-    pub gas_price: Option<UInt>,
-    /// The gas limit for the transaction.
-    pub gas_limit: Option<UInt>,
+    pub input_contract_id: Option<ContractId>,
+    pub policies_tip: Option<UInt>,
+    pub policies_witness_limit: Option<UInt>,
+    pub policies_maturity: Option<UInt>,
+    pub policies_max_fee: Option<UInt>,
+    /// The gas limit for the script.
+    pub script_gas_limit: Option<UInt>,
     /// The minimum block height that the transaction can be included at.
     pub maturity: Option<UInt>,
     /// The amount minted in the transaction.
     pub mint_amount: Option<UInt>,
     /// The asset ID for coins minted in the transaction.
     pub mint_asset_id: Option<Hash>,
+    pub mint_gas_price: Option<UInt>,
     /// The location of the transaction in the block.
     pub tx_pointer_block_height: Option<UInt>,
     pub tx_pointer_tx_index: Option<UInt>,
@@ -124,8 +132,13 @@ pub struct Transaction {
     pub script_data: Option<Data>,
     /// The witness index of contract bytecode.
     pub bytecode_witness_index: Option<UInt>,
-    /// The length of the transaction bytecode.
-    pub bytecode_length: Option<UInt>,
+    pub bytecode_root: Option<Hash>,
+    pub subsection_index: Option<UInt>,
+    pub subsection_number: Option<UInt>,
+    pub proof_set: Option<Vec<Data>>,
+    pub consensus_parameters_upgrade_purpose_witness_index: Option<UInt>,
+    pub consensus_parameters_upgrade_purpose_checksum: Option<Data>,
+    pub state_transition_upgrade_purpose_root: Option<Hash>,
     /// The salt value for the transaction.
     pub salt: Option<Data>,
 }
@@ -279,126 +292,3 @@ pub type Address = FixedSizeData<32>;
 
 // contract id is also a 32 byte hash
 pub type ContractId = FixedSizeData<32>;
-
-/*
-/// Evm block header object
-///
-/// See ethereum rpc spec for the meaning of fields
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockHeader {
-    pub number: BlockNumber,
-    pub hash: Hash,
-    pub parent_hash: Hash,
-    pub nonce: Option<Nonce>,
-    #[serde(default)]
-    pub sha3_uncles: Hash,
-    pub logs_bloom: BloomFilter,
-    pub transactions_root: Hash,
-    pub state_root: Hash,
-    pub receipts_root: Hash,
-    pub miner: Address,
-    pub difficulty: Option<Quantity>,
-    pub total_difficulty: Option<Quantity>,
-    pub extra_data: Data,
-    pub size: Quantity,
-    pub gas_limit: Quantity,
-    pub gas_used: Quantity,
-    pub timestamp: Quantity,
-    pub uncles: Option<Vec<Hash>>,
-    pub base_fee_per_gas: Option<Quantity>,
-}
-
-/// Evm block object
-///
-/// A block will contain a header and either a list of full transaction objects or
-/// a list of only transaction hashes.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Block<Tx> {
-    #[serde(flatten)]
-    pub header: BlockHeader,
-    pub transactions: Vec<Tx>,
-}
-
-/// Evm transaction object
-///
-/// See ethereum rpc spec for the meaning of fields
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Transaction {
-    pub block_hash: Hash,
-    pub block_number: BlockNumber,
-    pub from: Option<Address>,
-    pub gas: Quantity,
-    pub gas_price: Option<Quantity>,
-    pub hash: Hash,
-    pub input: Data,
-    pub nonce: Quantity,
-    pub to: Option<Address>,
-    pub transaction_index: TransactionIndex,
-    pub value: Quantity,
-    pub v: Option<Quantity>,
-    pub r: Option<Quantity>,
-    pub s: Option<Quantity>,
-    pub max_priority_fee_per_gas: Option<Quantity>,
-    pub max_fee_per_gas: Option<Quantity>,
-    pub chain_id: Option<Quantity>,
-}
-
-/// Evm transaction receipt object
-///
-/// See ethereum rpc spec for the meaning of fields
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransactionReceipt {
-    pub transaction_hash: Hash,
-    pub transaction_index: TransactionIndex,
-    pub block_hash: Hash,
-    pub block_number: BlockNumber,
-    pub from: Address,
-    pub to: Option<Address>,
-    pub cumulative_gas_used: Quantity,
-    #[serde(default)]
-    pub effective_gas_price: Quantity,
-    pub gas_used: Quantity,
-    pub contract_address: Option<Address>,
-    pub logs: Vec<Log>,
-    pub logs_bloom: BloomFilter,
-    #[serde(rename = "type")]
-    pub kind: Option<TransactionType>,
-    pub root: Option<Hash>,
-    pub status: Option<TransactionStatus>,
-}
-
-/// Evm log object
-///
-/// See ethereum rpc spec for the meaning of fields
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Log {
-    pub removed: Option<bool>,
-    pub log_index: LogIndex,
-    pub transaction_index: TransactionIndex,
-    pub transaction_hash: Hash,
-    pub block_hash: Hash,
-    pub block_number: BlockNumber,
-    pub address: Address,
-    pub data: Data,
-    pub topics: ArrayVec<LogArgument, 4>,
-}
-*/
-
-// /// EVM log argument is 32 bytes of data
-// pub type LogArgument = FixedSizeData<32>;
-
-// /// EVM address is 20 bytes of data
-// pub type Address = FixedSizeData<20>;
-
-// /// EVM nonce is 8 bytes of data
-// pub type Nonce = FixedSizeData<8>;
-
-// pub type BloomFilter = Data;
-// pub type BlockNumber = uint::UInt;
-// pub type TransactionIndex = uint::UInt;
-// pub type LogIndex = uint::UInt;

--- a/hyperfuel-format/src/types/mod.rs
+++ b/hyperfuel-format/src/types/mod.rs
@@ -89,7 +89,7 @@ pub struct Transaction {
     /// A pointer to the TX whose output is being spent for a contract used for the transaction input.
     pub input_contract_tx_pointer_tx_index: Option<UInt>,
     /// The contract id for a contract used for the transaction input.
-    pub input_contract_id: Option<ContractId>,
+    pub input_contract: Option<ContractId>,
     pub policies_tip: Option<UInt>,
     pub policies_witness_limit: Option<UInt>,
     pub policies_maturity: Option<UInt>,
@@ -115,7 +115,7 @@ pub struct Transaction {
     /// The state root of contract after transaction execution from a transaction that changed the state of a contract.
     pub output_contract_state_root: Option<Hash>,
     /// An array of witnesses.
-    pub witnesses: Option<Data>,
+    pub witnesses: Option<Data>, // TODO: only first one, but this is a vec
     /// The root of the receipts.
     pub receipts_root: Option<Hash>,
     /// The status type of the transaction.
@@ -134,8 +134,8 @@ pub struct Transaction {
     pub bytecode_witness_index: Option<UInt>,
     pub bytecode_root: Option<Hash>,
     pub subsection_index: Option<UInt>,
-    pub subsection_number: Option<UInt>,
-    pub proof_set: Option<Vec<Data>>,
+    pub subsections_number: Option<UInt>,
+    pub proof_set: Option<Data>, // TODO: only first one, but this is a vec
     pub consensus_parameters_upgrade_purpose_witness_index: Option<UInt>,
     pub consensus_parameters_upgrade_purpose_checksum: Option<Data>,
     pub state_transition_upgrade_purpose_root: Option<Hash>,

--- a/hyperfuel-format/src/types/transaction_type.rs
+++ b/hyperfuel-format/src/types/transaction_type.rs
@@ -13,6 +13,8 @@ pub enum TransactionType {
     Script,
     Create,
     Mint,
+    Upgrade,
+    Upload,
 }
 
 impl TransactionType {
@@ -21,6 +23,8 @@ impl TransactionType {
             0 => Ok(Self::Script),
             1 => Ok(Self::Create),
             2 => Ok(Self::Mint),
+            3 => Ok(Self::Upgrade),
+            4 => Ok(Self::Upload),
             _ => Err(Error::UnknownTransactionType(val.to_string())),
         }
     }
@@ -30,6 +34,8 @@ impl TransactionType {
             Self::Script => 0,
             Self::Create => 1,
             Self::Mint => 2,
+            Self::Upgrade => 3,
+            Self::Upload => 4,
         }
     }
 }
@@ -42,6 +48,8 @@ impl FromStr for TransactionType {
             "0x0" => Ok(Self::Script),
             "0x1" => Ok(Self::Create),
             "0x2" => Ok(Self::Mint),
+            "0x3" => Ok(Self::Upgrade),
+            "0x4" => Ok(Self::Upload),
             _ => Err(Error::UnknownTransactionType(s.to_owned())),
         }
     }
@@ -53,6 +61,8 @@ impl TransactionType {
             Self::Script => "0x0",
             Self::Create => "0x1",
             Self::Mint => "0x2",
+            Self::Upgrade => "0x3",
+            Self::Upload => "0x4",
         }
     }
 }
@@ -112,6 +122,8 @@ mod tests {
         assert_tokens(&TransactionType::Script, &[Token::Str("0x0")]);
         assert_tokens(&TransactionType::Create, &[Token::Str("0x1")]);
         assert_tokens(&TransactionType::Mint, &[Token::Str("0x2")]);
+        assert_tokens(&TransactionType::Upgrade, &[Token::Str("0x3")]);
+        assert_tokens(&TransactionType::Upload, &[Token::Str("0x4")]);
     }
 
     #[test]

--- a/hyperfuel-net-types/Cargo.toml
+++ b/hyperfuel-net-types/Cargo.toml
@@ -10,7 +10,7 @@ capnp = "0.18"
 serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
 
-hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "0.0.4" }
+hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "0.0.5" }
 
 [build-dependencies]
 capnpc = "0.18"

--- a/hyperfuel-net-types/Cargo.toml
+++ b/hyperfuel-net-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-net-types"
-version = "0.0.3"
+version = "1.0.0"
 edition = "2021"
 description = "hyperfuel types for transport over network"
 license = "MIT"
@@ -10,7 +10,7 @@ capnp = "0.18"
 serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
 
-hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "0.0.5" }
+hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "1.0.0" }
 
 [build-dependencies]
 capnpc = "0.18"

--- a/hyperfuel-schema/Cargo.toml
+++ b/hyperfuel-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-schema"
-version = "0.0.3"
+version = "1.0.0"
 edition = "2021"
 description = "schema utilities for hyperfuel"
 license = "MIT"

--- a/hyperfuel-schema/Cargo.toml
+++ b/hyperfuel-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-schema"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "schema utilities for hyperfuel"
 license = "MIT"

--- a/hyperfuel-schema/src/lib.rs
+++ b/hyperfuel-schema/src/lib.rs
@@ -80,7 +80,7 @@ pub fn transaction() -> SchemaRef {
         Field::new("subsection_index", DataType::UInt64, true), // new
         Field::new("subsections_number", DataType::UInt64, true), // new
         // vec
-        Field::new("storage_slots", DataType::Binary, true), // new
+        // Field::new("storage_slots", DataType::Binary, true), // new
         // vec
         Field::new("proof_set", DataType::Binary, true), // new
         Field::new(

--- a/hyperfuel-schema/src/lib.rs
+++ b/hyperfuel-schema/src/lib.rs
@@ -49,7 +49,7 @@ pub fn transaction() -> SchemaRef {
             true,
         ),
         Field::new("input_contract_tx_pointer_tx_index", DataType::UInt64, true),
-        Field::new("input_contract_id", DataType::Binary, true), // renamed
+        Field::new("input_contract", DataType::Binary, true),
         // Field::new("gas_price", DataType::UInt64, true), // removed
         Field::new("policies_tip", DataType::UInt64, true), // new
         Field::new("policies_witness_limit", DataType::UInt64, true), // new

--- a/hyperfuel-schema/src/lib.rs
+++ b/hyperfuel-schema/src/lib.rs
@@ -16,10 +16,13 @@ pub fn block_header() -> SchemaRef {
     Schema::from(vec![
         Field::new("id", DataType::Binary, false),
         Field::new("da_height", DataType::UInt64, false),
+        Field::new("consensus_parameters_version", DataType::UInt64, false), // new
+        Field::new("state_transition_bytecode_version", DataType::UInt64, false), // new
         Field::new("transactions_count", DataType::UInt64, false),
         Field::new("message_receipt_count", DataType::UInt64, false),
         Field::new("transactions_root", DataType::Binary, false),
-        Field::new("message_receipt_root", DataType::Binary, false),
+        Field::new("message_outbox_root", DataType::Binary, false), // renamed
+        Field::new("event_inbox_root", DataType::Binary, false),    // new
         Field::new("height", DataType::UInt64, false),
         Field::new("prev_root", DataType::Binary, false),
         Field::new("time", DataType::Int64, false),
@@ -46,15 +49,20 @@ pub fn transaction() -> SchemaRef {
             true,
         ),
         Field::new("input_contract_tx_pointer_tx_index", DataType::UInt64, true),
-        Field::new("input_contract", DataType::Binary, true),
-        Field::new("gas_price", DataType::UInt64, true),
-        Field::new("gas_limit", DataType::UInt64, true),
+        Field::new("input_contract_id", DataType::Binary, true), // renamed
+        // Field::new("gas_price", DataType::UInt64, true), // removed
+        Field::new("policies_tip", DataType::UInt64, true), // new
+        Field::new("policies_witness_limit", DataType::UInt64, true), // new
+        Field::new("policies_maturity", DataType::UInt64, true), // new
+        Field::new("policies_max_fee", DataType::UInt64, true), // new
+        Field::new("script_gas_limit", DataType::UInt64, true), // renamed
         Field::new("maturity", DataType::UInt64, true),
         Field::new("mint_amount", DataType::UInt64, true),
         Field::new("mint_asset_id", DataType::Binary, true),
+        Field::new("mint_gas_price", DataType::UInt64, true), // new
         Field::new("tx_pointer_block_height", DataType::UInt64, true),
         Field::new("tx_pointer_tx_index", DataType::UInt64, true),
-        Field::new("tx_type", DataType::UInt8, false),
+        Field::new("tx_type", DataType::UInt8, false), // not changes, but new tx_types (upgrade, upload)
         Field::new("output_contract_input_index", DataType::UInt64, true),
         Field::new("output_contract_balance_root", DataType::Binary, true),
         Field::new("output_contract_state_root", DataType::Binary, true),
@@ -67,7 +75,29 @@ pub fn transaction() -> SchemaRef {
         Field::new("script", DataType::Binary, true),
         Field::new("script_data", DataType::Binary, true),
         Field::new("bytecode_witness_index", DataType::UInt64, true),
-        Field::new("bytecode_length", DataType::UInt64, true),
+        // Field::new("bytecode_length", DataType::UInt64, true), // removed
+        Field::new("bytecode_root", DataType::Binary, true), // new
+        Field::new("subsection_index", DataType::UInt64, true), // new
+        Field::new("subsections_number", DataType::UInt64, true), // new
+        // vec
+        Field::new("storage_slots", DataType::Binary, true), // new
+        // vec
+        Field::new("proof_set", DataType::Binary, true), // new
+        Field::new(
+            "consensus_parameters_upgrade_purpose_witness_index",
+            DataType::UInt64,
+            true,
+        ), // new
+        Field::new(
+            "consensus_parameters_upgrade_purpose_checksum",
+            DataType::Binary,
+            true,
+        ), // new
+        Field::new(
+            "state_transition_upgrade_purpose_root",
+            DataType::Binary,
+            true,
+        ), // new
         Field::new("salt", DataType::Binary, true),
     ])
     .into()


### PR DESCRIPTION
Updated schema, format, and client for testnet and released new versions `1.0.0` for those crates.  `net-types` didn't need to be changed because there are no changes to the query struct.  Additionally noted the fields that are renamed, removed, or new in `schema/lib.rs`.