### PR TITLE
feat: added tx-status to query selections and schema/format for receipts, inputs, outputs

### DIFF
--- a/hyperfuel-client/Cargo.toml
+++ b/hyperfuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-client"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 description = "client library for Envio's HyperSync support of the Fuel Network"
 license = "MIT"
@@ -35,9 +35,9 @@ alloy-dyn-abi = "0.5.0"
 alloy-json-abi = "0.5.0"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
-hyperfuel-net-types = { package = "hyperfuel-net-types", path = "../hyperfuel-net-types", version = "1.0.0" }
-hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "1.0.0" }
-hyperfuel-schema = { package = "hyperfuel-schema", path = "../hyperfuel-schema", version = "1.0.0" }
+hyperfuel-net-types = { package = "hyperfuel-net-types", path = "../hyperfuel-net-types", version = "2.0.0" }
+hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "2.0.0" }
+hyperfuel-schema = { package = "hyperfuel-schema", path = "../hyperfuel-schema", version = "2.0.0" }
 
 [dependencies.reqwest]
 version = "0.11"

--- a/hyperfuel-client/src/from_arrow.rs
+++ b/hyperfuel-client/src/from_arrow.rs
@@ -448,6 +448,12 @@ impl FromArrow for Receipt {
             }
         }
 
+        if let Ok(col) = batch.column::<UInt8Array>("tx_status") {
+            for (target, val) in out.iter_mut().zip(col.values_iter()) {
+                target.tx_status = TransactionStatus::from_u8(*val).unwrap();
+            }
+        }
+
         if let Ok(col) = batch.column::<UInt64Array>("block_height") {
             for (target, &val) in out.iter_mut().zip(col.values_iter()) {
                 target.block_height = val.into();
@@ -611,6 +617,11 @@ impl FromArrow for Input {
                 target.tx_id = val.try_into().unwrap();
             }
         }
+        if let Ok(col) = batch.column::<UInt8Array>("tx_status") {
+            for (target, val) in out.iter_mut().zip(col.values_iter()) {
+                target.tx_status = TransactionStatus::from_u8(*val).unwrap();
+            }
+        }
         if let Ok(col) = batch.column::<BinaryArray<i32>>("utxo_id") {
             for (target, val) in out.iter_mut().zip(col.iter()) {
                 target.utxo_id = val.map(|v| v.try_into().unwrap());
@@ -718,6 +729,11 @@ impl FromArrow for Output {
         if let Ok(col) = batch.column::<BinaryArray<i32>>("tx_id") {
             for (target, val) in out.iter_mut().zip(col.values_iter()) {
                 target.tx_id = val.try_into().unwrap();
+            }
+        }
+        if let Ok(col) = batch.column::<UInt8Array>("tx_status") {
+            for (target, val) in out.iter_mut().zip(col.values_iter()) {
+                target.tx_status = TransactionStatus::from_u8(*val).unwrap();
             }
         }
         if let Ok(col) = batch.column::<BinaryArray<i32>>("to") {

--- a/hyperfuel-format/Cargo.toml
+++ b/hyperfuel-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-format"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 description = "fuel network format library"
 license = "MIT"

--- a/hyperfuel-format/src/types/mod.rs
+++ b/hyperfuel-format/src/types/mod.rs
@@ -153,6 +153,8 @@ pub struct Receipt {
     pub root_contract_id: Option<ContractId>,
     /// transaction that this receipt originated from
     pub tx_id: Hash,
+    /// The status type of the transaction this receipt originated from
+    pub tx_status: TransactionStatus,
     /// block that the receipt originated in
     pub block_height: UInt,
     /// The value of the program counter register $pc, which is the memory address of the current instruction.
@@ -217,6 +219,8 @@ pub struct Receipt {
 pub struct Input {
     /// transaction that this input originated from
     pub tx_id: Hash,
+    /// The status type of the transaction this input originated from
+    pub tx_status: TransactionStatus,
     /// block that the input originated in
     pub block_height: UInt,
     /// InputCoin, InputContract, or InputMessage
@@ -263,6 +267,8 @@ pub struct Input {
 pub struct Output {
     /// transaction that this out originated from
     pub tx_id: Hash,
+    /// The status type of the transaction this output originated from
+    pub tx_status: TransactionStatus,
     /// block that the output originated in
     pub block_height: UInt,
     /// CoinOutput, ContractOutput, ChangeOutput, VariableOutput, or ContractCreated

--- a/hyperfuel-net-types/Cargo.toml
+++ b/hyperfuel-net-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-net-types"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 description = "hyperfuel types for transport over network"
 license = "MIT"
@@ -10,7 +10,7 @@ capnp = "0.18"
 serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
 
-hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "1.0.0" }
+hyperfuel-format = { package = "hyperfuel-format", path = "../hyperfuel-format", version = "2.0.0" }
 
 [build-dependencies]
 capnpc = "0.18"

--- a/hyperfuel-net-types/src/lib.rs
+++ b/hyperfuel-net-types/src/lib.rs
@@ -33,6 +33,8 @@ pub struct ReceiptSelection {
     pub rc: Vec<u64>,
     #[serde(default)]
     pub rd: Vec<u64>,
+    #[serde(default)]
+    pub tx_status: Vec<u8>,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
@@ -49,6 +51,8 @@ pub struct InputSelection {
     pub recipient: Vec<Hash>,
     #[serde(default)]
     pub input_type: Vec<u8>,
+    #[serde(default)]
+    pub tx_status: Vec<u8>,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
@@ -61,6 +65,8 @@ pub struct OutputSelection {
     pub contract: Vec<Hash>,
     #[serde(default)]
     pub output_type: Vec<u8>,
+    #[serde(default)]
+    pub tx_status: Vec<u8>,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]

--- a/hyperfuel-schema/Cargo.toml
+++ b/hyperfuel-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-schema"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 description = "schema utilities for hyperfuel"
 license = "MIT"

--- a/hyperfuel-schema/src/lib.rs
+++ b/hyperfuel-schema/src/lib.rs
@@ -69,7 +69,7 @@ pub fn transaction() -> SchemaRef {
         // vec
         Field::new("witnesses", DataType::Binary, true),
         Field::new("receipts_root", DataType::Binary, true),
-        Field::new("status", DataType::UInt8, true),
+        Field::new("status", DataType::UInt8, false),
         Field::new("time", DataType::Int64, false),
         Field::new("reason", DataType::Utf8, true),
         Field::new("script", DataType::Binary, true),
@@ -109,6 +109,7 @@ pub fn receipt() -> SchemaRef {
         Field::new("receipt_index", DataType::UInt64, false),
         Field::new("root_contract_id", DataType::Binary, true),
         Field::new("tx_id", DataType::Binary, false),
+        Field::new("tx_status", DataType::UInt8, false), // new
         Field::new("block_height", DataType::UInt64, false),
         Field::new("pc", DataType::UInt64, true),
         Field::new("is", DataType::UInt64, true),
@@ -145,6 +146,7 @@ pub fn input() -> SchemaRef {
     Schema::from(vec![
         // for mapping
         Field::new("tx_id", DataType::Binary, false),
+        Field::new("tx_status", DataType::UInt8, false), // new
         Field::new("block_height", DataType::UInt64, false),
         Field::new("input_type", DataType::UInt8, false),
         Field::new("utxo_id", DataType::Binary, true),
@@ -172,6 +174,7 @@ pub fn output() -> SchemaRef {
     Schema::from(vec![
         // for mapping
         Field::new("tx_id", DataType::Binary, false),
+        Field::new("tx_status", DataType::UInt8, false), // new
         Field::new("block_height", DataType::UInt64, false),
         Field::new("output_type", DataType::UInt8, false),
         Field::new("to", DataType::Binary, true),


### PR DESCRIPTION
Changed schema and format to include `tx_status` on receipts, inputs, and outputs.

Changed net-types to include `tx_status` into selections for receipts, inputs, and outputs.

Changed client to convert this new field and filter out receipts, inputs, and outputs that don't have the selected tx_selection