### PR TITLE
feat: added function get_selected_arrow_data(query)

### DIFF
--- a/hyperfuel-client/Cargo.toml
+++ b/hyperfuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperfuel-client"
-version = "2.1.1"
+version = "2.2.1"
 edition = "2021"
 description = "client library for Envio's HyperSync support of the Fuel Network"
 license = "MIT"
@@ -9,14 +9,14 @@ license = "MIT"
 anyhow = "1"
 url = { version = "2", features = ["serde"] }
 arrow2 = { version = "0.18", features = [
-    "io_json",
-    "io_ipc",
-    "io_ipc_compression",
-    "io_parquet_zstd",
-    "io_parquet_lz4",
-    "io_parquet",
-    "compute_boolean",
-    "compute_filter",
+	"io_json",
+	"io_ipc",
+	"io_ipc_compression",
+	"io_parquet_zstd",
+	"io_parquet_lz4",
+	"io_parquet",
+	"compute_boolean",
+	"compute_filter",
 ] }
 serde_json = "1"
 capnp = "0.18"
@@ -24,8 +24,8 @@ serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 arrayvec = { version = "0.7", features = ["serde"] }
 tokio = { version = "1", default-features = false, features = [
-    "rt-multi-thread",
-    "fs",
+	"rt-multi-thread",
+	"fs",
 ] }
 log = "0.4"
 fastrange-rs = "0.1"


### PR DESCRIPTION
Works the same as `get_selected_data(query)` but returns arrow data instead of typed data