### PR TITLE
publish.yaml: switch to crates.io trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,7 @@ name: Publish to crates.io
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -23,7 +24,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
       - name: Install Dependencies
@@ -31,10 +32,11 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev
 
-      - uses: actions/checkout@v2
-      - name: Run publish script
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish to crates.io
         env:
-          VERBOSE: true
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          cargo publish -p ${{ inputs.crate_name }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish -p ${{ inputs.crate_name }}


### PR DESCRIPTION
## What

Switches the manual \`cargo publish\` workflow from the long-lived \`CARGO_REGISTRY_TOKEN\` repo secret to crates.io's trusted publishing (OIDC).

All four crates - \`hyperfuel-format\`, \`hyperfuel-schema\`, \`hyperfuel-net-types\`, \`hyperfuel-client\` - have already been configured on crates.io to trust this repo + \`publish.yaml\` as a publisher (no GitHub environment requirement, matching the current lack of env-gating on the secret).

## Changes

- Add \`id-token: write\` permission so GitHub Actions issues the OIDC token the auth action exchanges.
- New \`rust-lang/crates-io-auth-action@v1\` step yields a short-lived token via \`steps.auth.outputs.token\`.
- Publish step now reads \`CARGO_REGISTRY_TOKEN\` from that step output instead of \`secrets.CARGO_REGISTRY_TOKEN\`.
- Cleanups: bump \`actions/checkout\` v3 → v4, drop the leftover duplicate \`actions/checkout@v2\` and unused \`VERBOSE: true\` env.

The \`capnproto libcapnp-dev\` install step is kept because \`hyperfuel-net-types\` still has \`build.rs\` running \`capnpc\`. Dmitri's earlier proposal to drop \`build.rs\` (originally PR #8) can be reapplied on top of the new baseline as a separate follow-up; the apt-install step can disappear then.

## After this merges

1. Run the workflow once (any of the four crates, manual dispatch) to confirm the OIDC handshake works end-to-end. Pick a crate that's safe to re-publish at its current version, or just dry-run the auth step with a no-op publish target if you'd rather not bump a version yet.
2. Delete the \`CARGO_REGISTRY_TOKEN\` repo (and/or org) secret in GitHub Settings → Secrets - no workflow references it anymore.

## Optional security upgrade (not in this PR)

If you ever want reviewer approval gating on publishes: create a \`release\` GitHub environment with required reviewers, add \`environment: release\` on the \`publish_crates\` job, and edit each crate's trusted publisher on crates.io to set the same environment name. Both sides must agree or publishes will fail.

## Depends on

#9 (migration baseline). This PR's workflow file change is independent of that PR's content, but conceptually the trusted-publishing handoff makes most sense applied on top of the reconciled v2 baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing process with improved authentication mechanisms and updated build system dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hyperfuel-client-rust/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->